### PR TITLE
Patch wireguard-linux-compat to skip kernel version check

### DIFF
--- a/Dockerfile.raspberrypi3
+++ b/Dockerfile.raspberrypi3
@@ -30,8 +30,14 @@ ARG WITH_WGQUICK=yes
 RUN make -C wireguard-tools-${WG_TOOLS_TAG}/src -j"$(nproc)" && \
     make -C wireguard-tools-${WG_TOOLS_TAG}/src install
 
+# strip the kernel version check
+# https://forums.balena.io/t/using-wireguard-with-new-os-releases/344047/8
+# https://gist.github.com/mattmacleod/c6589fadeaaf83f2c7d75321d9172bbe
+COPY wireguard-linux-compat.patch .
+
 # build wireguard kernel module
-RUN make -C kernel_modules_headers modules_prepare -j"$(nproc)" && \
+RUN patch -d /usr/src/app/wireguard-linux-compat-${WG_LINUX_TAG}/ -p0 < wireguard-linux-compat.patch && \
+    make -C kernel_modules_headers modules_prepare -j"$(nproc)" && \
     make -C kernel_modules_headers M=/usr/src/app/wireguard-linux-compat-${WG_LINUX_TAG}/src -j"$(nproc)"
 
 FROM balenalib/raspberrypi3-alpine:3.13-run-20210602 AS run

--- a/wireguard-linux-compat.patch
+++ b/wireguard-linux-compat.patch
@@ -1,0 +1,13 @@
+--- src/compat/compat.h	2021-08-10 19:15:01.000000000 +0100
++++ src/compat/compat.h	2021-08-10 19:15:02.000000000 +0100
+@@ -39,10 +39,6 @@
+ #error "WireGuard requires Linux >= 3.10"
+ #endif
+
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+-#error "WireGuard has been merged into Linux >= 5.6 and therefore this compatibility module is no longer required."
+-#endif
+-
+ #if defined(ISRHEL7)
+ #include <linux/skbuff.h>
+ #define headers_end headers_start


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>