### PR TITLE
Build from kernel_source rather than kernel_modules_headers

### DIFF
--- a/Dockerfile.raspberrypi3
+++ b/Dockerfile.raspberrypi3
@@ -18,7 +18,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN curl -L https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${WG_GO_TAG}.tar.xz | tar xJ && \
     curl -L https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${WG_TOOLS_TAG}.tar.xz | tar xJ && \
     curl -L https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-${WG_LINUX_TAG}.tar.xz | tar xJ && \
-    curl -L https://files.balena-cloud.com/images/${BALENA_MACHINE_NAME}/${BALENA_OS_VERSION}/kernel_modules_headers.tar.gz | tar xz
+    curl -L https://files.balena-cloud.com/images/${BALENA_MACHINE_NAME}/${BALENA_OS_VERSION}/kernel_source.tar.gz | tar xz --strip-components=2
 
 # build and install wireguard-go
 RUN make -C wireguard-go-${WG_GO_TAG} -j"$(nproc)" && \
@@ -37,8 +37,8 @@ COPY wireguard-linux-compat.patch .
 
 # build wireguard kernel module
 RUN patch -d /usr/src/app/wireguard-linux-compat-${WG_LINUX_TAG}/ -p0 < wireguard-linux-compat.patch && \
-    make -C kernel_modules_headers modules_prepare -j"$(nproc)" && \
-    make -C kernel_modules_headers M=/usr/src/app/wireguard-linux-compat-${WG_LINUX_TAG}/src -j"$(nproc)"
+    make -C build modules_prepare -j"$(nproc)" && \
+    make -C build M=/usr/src/app/wireguard-linux-compat-${WG_LINUX_TAG}/src -j"$(nproc)"
 
 FROM balenalib/raspberrypi3-alpine:3.13-run-20210602 AS run
 


### PR DESCRIPTION
The `kernel_modules_headers` package is being deprecated as per this issue:
https://github.com/balena-os/meta-balena/issues/2289

Signed-off-by: Kyle Harding <kyle@balena.io>