### PR TITLE
Split versionist and balena actions to run in parallel

### DIFF
--- a/.github/workflows/balena.yml
+++ b/.github/workflows/balena.yml
@@ -2,6 +2,8 @@ name: balena
 
 on:
   push:
+    branches:
+      - "main"
     tags:
       - "v*"
   pull_request:
@@ -11,57 +13,56 @@ on:
 env:
   BALENARC_BALENA_URL: balena-cloud.com
   BALENARC_PROXY_URL: balena-devices.com
-  BALENA_CLI_VERSION: 12.48.7
+  BALENA_CLI_VERSION: 12.48.11
 
 jobs:
   build:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 12
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-    - name: Install balena CLI
-      run: npm install balena-cli@${{ env.BALENA_CLI_VERSION }} --production --global
+      - id: npm_install
+        run: npm install balena-cli@${{ env.BALENA_CLI_VERSION }} --production --global
 
-    - name: Login to balenaCloud
-      run: balena login --token "${{ secrets.BALENA_API_KEY }}"
+      - id: balena_login
+        run: balena login --token "${{ secrets.BALENA_API_KEY }}"
 
-    - name: Enable draft option
-      if: github.event_name == 'pull_request'
-      run: echo "DRAFT=--draft" >> $GITHUB_ENV
+      - id: is_pr
+        if: github.event_name == 'pull_request'
+        run: echo "::set-output name=draft::--draft"
 
-    - name: Push to balenaCloud
-      run: |
-        balena push ${{ secrets.BALENA_FLEET_SLUG }} \
-          --release-tag GITHUB_WORKFLOW "${GITHUB_WORKFLOW}" \
-          --release-tag GITHUB_RUN_ID "${GITHUB_RUN_ID}" \
-          --release-tag GITHUB_RUN_NUMBER "${GITHUB_RUN_NUMBER}" \
-          --release-tag GITHUB_ACTOR "${GITHUB_ACTOR}" \
-          --release-tag GITHUB_SHA "${GITHUB_SHA}" \
-          --release-tag GITHUB_REF "${GITHUB_REF}" \
-          ${DRAFT} | tee build.log
+      - id: balena_push
+        shell: bash
+        run: |
+          balena push ${{ secrets.BALENA_FLEET_SLUG }} \
+            --release-tag GITHUB_WORKFLOW "${GITHUB_WORKFLOW}" \
+            --release-tag GITHUB_RUN_ID "${GITHUB_RUN_ID}" \
+            --release-tag GITHUB_RUN_NUMBER "${GITHUB_RUN_NUMBER}" \
+            --release-tag GITHUB_ACTOR "${GITHUB_ACTOR}" \
+            --release-tag GITHUB_SHA "${GITHUB_SHA}" \
+            --release-tag GITHUB_REF "${GITHUB_REF}" \
+            ${{ steps.is_pr.outputs.draft }} | tee build.log
+          sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" -i build.log
+          grep -q 'Release successfully created!' build.log
+          echo "::set-output name=release_id::$(sed -rn 's/.*Release: ([[:alnum:]]+) \(id: ([0-9]+)\)/\2/p' build.log)"
 
-    - name: Parse release ID from build log
-      run: |
-        set -o pipefail
-        cat build.log | \
-          sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" | \
-          sed -rn 's/.*Release: ([[:alnum:]]+) \(id: ([0-9]+)\)/RELEASE_ID=\2/p' >> $GITHUB_ENV
+      - id: release_api
+        if: ${{ steps.balena_push.outputs.release_id }} != ""
+        shell: bash
+        run: |
+          echo "::set-output name=release_version::$(curl -fsSL -X GET \
+            "https://api.${{ env.BALENARC_BALENA_URL }}/v6/release(${{ steps.balena_push.outputs.release_id }})?\$select=version" \
+            -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.BALENA_API_KEY }}" | jq -r '.d[].version.raw')"
 
-    - name: Get release version from balena API
-      run: |
-        set -o pipefail
-        curl -fsSL -X GET \
-          "https://api.${{ env.BALENARC_BALENA_URL }}/v6/release(${{ env.RELEASE_ID }})?\$select=version" \
-          -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.BALENA_API_KEY }}" | \
-           jq -r '.d[].version.raw' | sed 's/^/RELEASE_VERSION=/' >> $GITHUB_ENV
-
-    - uses: tvdias/github-tagger@v0.0.2
-      if: github.event_name == 'pull_request'
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        tag: "v${{ env.RELEASE_VERSION }}"
+      # requires with 'repo' access.
+      # using GITHUB_TOKEN will NOT trigger other workflows
+      - uses: tvdias/github-tagger@v0.0.2
+        if: ${{ steps.release_api.outputs.release_version }} != ""
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "v${{ steps.release_api.outputs.release_version }}"

--- a/.github/workflows/versionist.yml
+++ b/.github/workflows/versionist.yml
@@ -6,24 +6,21 @@ on:
       - "main"
 
 jobs:
-
   versionist:
-    if: "!contains(github.event.head_commit.author.name, 'versionist')"
     runs-on: ubuntu-20.04
 
     steps:
-
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           persist-credentials: false
 
+      # requires with 'repo' access.
+      # using GITHUB_TOKEN will NOT trigger other workflows
       - id: versionist
         uses: tmigone/versionist@v0.4.6
         with:
-          github_email: 'versionist@users.noreply.github.com'
-          github_username: 'versionist'
-          # VERSIONIST_TOKEN requires 'repo' access.
-          # Don't use GITHUB_TOKEN if you want this commit to trigger other workflows.
-          github_token: ${{ secrets.VERSIONIST_TOKEN }}
+          github_email: "versionist@users.noreply.github.com"
+          github_username: "versionist"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: main

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ Additional usage instructions for wireguard can be found here: <https://www.wire
 
 Please open an issue or submit a pull request with any features, fixes, or changes.
 
+## Versioning
+
+Note that the current CI workflow will bump the version in
+the main branch _after_the merged balenaCloud release has
+been deployed as final.
+
+As such, breaking changes may be introduced in `x.y.z-rev`
+releases in the balenaCloud dashboard with no indication
+that the major version was bumped as part of the same merge.
+
+However each balenaCloud release version (draft or final)
+will be tagged on the associated git commit so that should
+be used as the source of truth.
+
 ## Acknowledgements
 
 - <https://www.balena.io/blog/how-to-run-wireguard-vpn-in-balenaos/>


### PR DESCRIPTION
This has an impact on versioning in the main branch.

Note that the current CI workflow will bump the version in
the main branch _after_the merged balenaCloud release has
been deployed as final.

As such, breaking changes may be introduced in `x.y.z-rev`
releases in the balenaCloud dashboard with no indication
that the major version was bumped as part of the same merge.

However each balenaCloud release version (draft or final)
will be tagged on the associated git commit so that should
be used as the source of truth.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>