### PR TITLE
Allow passing ARG options to build kernel module from docker-compose file

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -62,7 +62,7 @@ RUN patch -d /usr/src/app/wireguard-linux-compat-${WG_LINUX_TAG}/ -p0 < wireguar
 # Set both of these to match your target device to pre-build modules
 # Leave at least one of them unset to postpone module building to app start
 ARG BALENA_DEVICE_TYPE=%%BALENA_MACHINE_NAME%%
-# ARG BALENA_HOST_OS_VERSION=2.80.3+rev1
+ARG BALENA_HOST_OS_VERSION
 
 COPY buildmod.sh ./
 RUN chmod +x ./buildmod.sh && ./buildmod.sh

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ ARG BALENA_DEVICE_TYPE=%%BALENA_MACHINE_NAME%%
 ARG BALENA_HOST_OS_VERSION=2.80.3+rev1
 ```
 
+Alternatively, you can set the ARGS via `docker-compose.yml` file:
+
+```yaml
+services:
+  wireguard:
+    build: 
+        context: .
+        dockerfile: Dockerfile.template
+        args:
+            BALENA_DEVICE_TYPE: raspberrypi4-64
+            BALENA_HOST_OS_VERSION: 2.85.2+rev3
+    privileged: true
+```
+
 This makes for much faster app startup but must match the environment
 of the target device.
 


### PR DESCRIPTION
This allows setting the required ARGS on `docker-compose.yml` and thus eliminating the need for me to fork the project to deploy it :)

Tested it and declaring `ARG BALENA_HOST_OS_VERSION` without setting it won't trigger a module build on build time as expected.