### PR TITLE
Don't error out if wireguard-go doesn't exist when removing it

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -61,7 +61,7 @@ server_pub_path="${config_root}"/wg0.pub
 if [ -n "${DISABLE_USERSPACE:-}" ]
 then
     info "Removing wireguard-go userspace module..."
-    rm -f /usr/bin/wireguard-go
+    rm /usr/bin/wireguard-go 2>/dev/null || true
 fi
 
 if ! do_insmod

--- a/run.sh
+++ b/run.sh
@@ -61,7 +61,7 @@ server_pub_path="${config_root}"/wg0.pub
 if [ -n "${DISABLE_USERSPACE:-}" ]
 then
     info "Removing wireguard-go userspace module..."
-    rm /usr/bin/wireguard-go
+    rm -f /usr/bin/wireguard-go
 fi
 
 if ! do_insmod


### PR DESCRIPTION
Context: `DISABLE_USERSPACE=1`

Container restarting with the following:

```
28.09.21 13:51:49 (-0300)  wireguard  [INFO] Removing wireguard-go userspace module...
28.09.21 13:51:49 (-0300)  wireguard  rm: can't remove '/usr/bin/wireguard-go': No such file or directory
```