### PR TITLE
Replace libqrencode with libqrencode-tools

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -15,6 +15,7 @@ jobs:
       FLOWZONE_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
       BALENA_API_KEY: ${{ secrets.BALENA_API_KEY }}
     with:
+      toggle_auto_merge: false
       balena_slugs: |
         gh_klutchell/wireguard-amd64,
         gh_klutchell/wireguard-aarch64,

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
     kmod \
     openresolv \
     iproute2 \
-    libqrencode \
+    libqrencode-tools \
     gettext \
     ipcalc \
     openssl-dev \


### PR DESCRIPTION
qrencode used to be part of libqrencode but now it's part of libqrencode-tools

Change-type: patch
Resolves: https://github.com/klutchell/balena-wireguard/issues/87